### PR TITLE
Implement Swagger documentation

### DIFF
--- a/SIT331_4.1P/4.1P.csproj
+++ b/SIT331_4.1P/4.1P.csproj
@@ -4,10 +4,13 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="8.0.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SIT331_4.1P/MapsController.cs
+++ b/SIT331_4.1P/MapsController.cs
@@ -9,10 +9,20 @@ namespace robot_controller_api.Controllers
     [Route("api/[controller]")]
     public class MapsController : ControllerBase
     {
+        /// <summary>
+        /// Gets all maps.
+        /// </summary>
+        /// <returns>A list of maps.</returns>
         [HttpGet]
         public IEnumerable<Map> GetAll() =>
             MapDataAccess.GetMaps();
 
+        /// <summary>
+        /// Gets a specific map.
+        /// </summary>
+        /// <param name="id">Map identifier.</param>
+        /// <returns>The requested map.</returns>
+        /// <response code="404">If the map is not found.</response>
         [HttpGet("{id}")]
         public ActionResult<Map> Get(int id)
         {
@@ -21,6 +31,12 @@ namespace robot_controller_api.Controllers
             return map;
         }
 
+        /// <summary>
+        /// Creates a map.
+        /// </summary>
+        /// <param name="map">A new map.</param>
+        /// <returns>The created map.</returns>
+        /// <response code="201">Returns the newly created map.</response>
         [HttpPost]
         public ActionResult<Map> Create(Map map)
         {
@@ -28,6 +44,14 @@ namespace robot_controller_api.Controllers
             return CreatedAtAction(nameof(Get), new { id = created.Id }, created);
         }
 
+        /// <summary>
+        /// Updates a map.
+        /// </summary>
+        /// <param name="id">Map identifier.</param>
+        /// <param name="map">Updated map.</param>
+        /// <response code="204">Map updated successfully.</response>
+        /// <response code="400">If identifiers do not match.</response>
+        /// <response code="404">If the map is not found.</response>
         [HttpPut("{id}")]
         public IActionResult Update(int id, Map map)
         {
@@ -37,6 +61,12 @@ namespace robot_controller_api.Controllers
             return NoContent();
         }
 
+        /// <summary>
+        /// Deletes a map.
+        /// </summary>
+        /// <param name="id">Map identifier.</param>
+        /// <response code="204">Map deleted successfully.</response>
+        /// <response code="404">If the map is not found.</response>
         [HttpDelete("{id}")]
         public IActionResult Delete(int id)
         {

--- a/SIT331_4.1P/Program.cs
+++ b/SIT331_4.1P/Program.cs
@@ -1,8 +1,38 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+using System.Reflection;
 
 var builder = WebApplication.CreateBuilder(args);
+
 builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new OpenApiInfo
+    {
+        Title = "Robot Controller API",
+        Description = "New backend service that provides resources for the Moon robot simulator.",
+        Contact = new OpenApiContact
+        {
+            Name = "Max Slavnenko",
+            Email = "m.slavnenko@deakin.edu.au"
+        }
+    });
+
+    var xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+    options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));
+});
+
 var app = builder.Build();
+
+app.UseStaticFiles();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI(setup => setup.InjectStylesheet("/styles/theme-flattop.css"));
+}
+
 app.MapControllers();
 app.Run();

--- a/SIT331_4.1P/RobotCommandsController.cs
+++ b/SIT331_4.1P/RobotCommandsController.cs
@@ -9,10 +9,20 @@ namespace robot_controller_api.Controllers
     [Route("api/[controller]")]
     public class RobotCommandsController : ControllerBase
     {
+        /// <summary>
+        /// Gets all robot commands.
+        /// </summary>
+        /// <returns>A list of robot commands.</returns>
         [HttpGet]
         public IEnumerable<RobotCommand> GetAll() =>
             RobotCommandDataAccess.GetRobotCommands();
 
+        /// <summary>
+        /// Gets a specific robot command.
+        /// </summary>
+        /// <param name="id">Command identifier.</param>
+        /// <returns>The requested robot command.</returns>
+        /// <response code="404">If the command is not found.</response>
         [HttpGet("{id}")]
         public ActionResult<RobotCommand> Get(int id)
         {
@@ -21,6 +31,12 @@ namespace robot_controller_api.Controllers
             return rc;
         }
 
+        /// <summary>
+        /// Creates a robot command.
+        /// </summary>
+        /// <param name="rc">A new robot command.</param>
+        /// <returns>The created robot command.</returns>
+        /// <response code="201">Returns the newly created command.</response>
         [HttpPost]
         public ActionResult<RobotCommand> Create(RobotCommand rc)
         {
@@ -28,6 +44,14 @@ namespace robot_controller_api.Controllers
             return CreatedAtAction(nameof(Get), new { id = created.Id }, created);
         }
 
+        /// <summary>
+        /// Updates a robot command.
+        /// </summary>
+        /// <param name="id">Command identifier.</param>
+        /// <param name="rc">Updated robot command.</param>
+        /// <response code="204">Command updated successfully.</response>
+        /// <response code="400">If identifiers do not match.</response>
+        /// <response code="404">If the command is not found.</response>
         [HttpPut("{id}")]
         public IActionResult Update(int id, RobotCommand rc)
         {
@@ -37,6 +61,12 @@ namespace robot_controller_api.Controllers
             return NoContent();
         }
 
+        /// <summary>
+        /// Deletes a robot command.
+        /// </summary>
+        /// <param name="id">Command identifier.</param>
+        /// <response code="204">Command deleted successfully.</response>
+        /// <response code="404">If the command is not found.</response>
         [HttpDelete("{id}")]
         public IActionResult Delete(int id)
         {


### PR DESCRIPTION
## Summary
- configure Swagger UI in Program.cs
- enable XML documentation generation and add Swashbuckle package
- document RobotCommands and Maps controllers

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841118c71148330bcb18cab9d4285cd