### PR TITLE
Load DB connection from configuration

### DIFF
--- a/SIT331_5.1P/MapDataAccess.cs
+++ b/SIT331_5.1P/MapDataAccess.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
 using Npgsql;
 using robot_controller_api.Models;
 
@@ -6,8 +7,19 @@ namespace robot_controller_api.Persistence
 {
     public static class MapDataAccess
     {
-        private const string CONNECTION_STRING =
-            "Host=localhost;Username=postgres;Password=;Database=sit331";
+        private static readonly string CONNECTION_STRING;
+
+        static MapDataAccess()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json", optional: true)
+                .AddEnvironmentVariables()
+                .Build();
+
+            CONNECTION_STRING = configuration.GetConnectionString("Default") ??
+                throw new InvalidOperationException(
+                    "Connection string 'Default' not found.");
+        }
 
         public static List<Map> GetMaps()
         {

--- a/SIT331_5.1P/RobotCommandDataAccess.cs
+++ b/SIT331_5.1P/RobotCommandDataAccess.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
 using Npgsql;
 using robot_controller_api.Models;
 
@@ -7,8 +8,19 @@ namespace robot_controller_api.Persistence
 {
     public static class RobotCommandDataAccess
     {
-        private const string CONNECTION_STRING =
-            "Host=localhost;Username=postgres;Password=;Database=sit331";
+        private static readonly string CONNECTION_STRING;
+
+        static RobotCommandDataAccess()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json", optional: true)
+                .AddEnvironmentVariables()
+                .Build();
+
+            CONNECTION_STRING = configuration.GetConnectionString("Default") ??
+                throw new InvalidOperationException(
+                    "Connection string 'Default' not found.");
+        }
 
         public static List<RobotCommand> GetRobotCommands()
         {

--- a/SIT331_5.1P/appsettings.json
+++ b/SIT331_5.1P/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "Default": "Host=localhost;Username=postgres;Password=;Database=sit331"
+  }
+}


### PR DESCRIPTION
## Summary
- support configuration-based connection strings
- add `appsettings.json`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841dbc3d93c8330b82d4e4c086347a8